### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Managed by CODEOWNERS rollout
 * @kiddom/open-academic-format-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kiddom/open-academic-format-codeowners


### PR DESCRIPTION
Create repo codeowners team, add top engineering contributors, and point CODEOWNERS to the team.